### PR TITLE
[#80] revise wording in login menu. from "user name" to "email".

### DIFF
--- a/data/menu.html
+++ b/data/menu.html
@@ -30,7 +30,7 @@
         <br>
         Note: This function is at the experimental stage.
       </p>
-      <label>user name
+      <label>email
         <input id="user-input" type="text" name="username" size="20">
       </label>
       <label>password


### PR DESCRIPTION
## pull request for #80 

## updates
* change label from "user name" to "email" in login menu